### PR TITLE
feat: Display social media links

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "next": "13.2.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-icons": "^4.8.0",
     "typescript": "5.0.2"
   },
   "devDependencies": {

--- a/src/components/LinkIcon.tsx
+++ b/src/components/LinkIcon.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+import type { IconType } from 'react-icons';
+
+type LinkIconProps = {
+  link: string;
+  Icon: IconType;
+  className?: string;
+};
+
+function LinkIcon(props: LinkIconProps) {
+  const { Icon, link, className } = props;
+  return (
+    <Link href={link} target="_blank">
+      <Icon
+        className={`inline-block text-dracula-light-100 hover:text-dracula-light-700 duration-500 ${className}`}
+      />
+    </Link>
+  );
+}
+
+export default LinkIcon;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,8 @@
+import LinkIcon from '@/components/LinkIcon';
 import Head from 'next/head';
 import Link from 'next/link';
+
+import { FaLinkedin, FaGithub, FaInstagram } from 'react-icons/fa';
 
 export default function Home() {
   return (
@@ -14,23 +17,37 @@ export default function Home() {
       <div className={'w-screen h-screen flex flex-col justify-center gap-y-8'}>
         <h1
           className={
-            'text-dracula-green text-center md:text-8xl sm:text-6xl text-4xl font-medium'
+            'text-dracula-pink text-center md:text-8xl sm:text-6xl text-4xl font-medium'
           }
         >
           khanguslee
         </h1>
 
-        <div className={'text-dracula-pink text-center text-sm'}>
-          <p>
+        <div className={'text-center'}>
+          <p className="text-dracula-green text-sm">
             Software Engineer @{' '}
             <Link
               href="https://www.mongodb.com/products/charts"
               target="_blank"
-              className="underline hover:text-dracula-pink-100 duration-500"
+              className="underline hover:text-dracula-green-900 duration-500"
             >
               MongoDB Atlas Charts
             </Link>
           </p>
+
+          <div className="text-4xl mt-2 flex flex-row justify-center space-x-8">
+            <LinkIcon
+              link="https://www.linkedin.com/in/kuanhoulee/"
+              Icon={FaLinkedin}
+            />
+
+            <LinkIcon link="https://github.com/khanguslee" Icon={FaGithub} />
+
+            <LinkIcon
+              link="https://www.instagram.com/khanguslee"
+              Icon={FaInstagram}
+            />
+          </div>
         </div>
       </div>
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2199,6 +2199,11 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-icons@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.8.0.tgz#621e900caa23b912f737e41be57f27f6b2bff445"
+  integrity sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
Closes #3 

- Adds `react-icon` package
- Create a `LinkIcon` component
- Display links to linkedin, github and instagram accounts